### PR TITLE
feat: Hook up contact page with WP

### DIFF
--- a/src/components/ContactDetails.js
+++ b/src/components/ContactDetails.js
@@ -1,56 +1,15 @@
 import React from "react"
 
-export default ({ clients, category }) => {
+export default ({ title, description, linkText, link }) => {
   return (
-    <div className="w-2/6 ml-auto">
-      <div>
-        <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
-          Careers
-        </span>
-        <p className="py-2 text-xs font-serif">
-          See open positions or send in a general application.
-        </p>
-        <a
-          className="text-xs text-bittersweet font-sans"
-          href="https://jobs.obvious.in/"
-        >
-          Apply
-        </a>
-      </div>
-      <div>
-        <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
-          Email
-        </span>
-        <a href="mailto:hello@obvious.in" className="py-2 text-xs font-serif">
-          hello@obvious.in
-        </a>
-      </div>
-      <div>
-        <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
-          Call
-        </span>
-        <a href="tel:+91 80 2919 92919" className="py-2 text-xs font-serif">
-          +91 80 2919 92919
-        </a>
-      </div>
-      <div>
-        <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
-          Visit Us
-        </span>
-        <p className="py-2 text-xs font-serif">
-          Level 2, Raheja Paramount
-          <br />
-          138 Residency Road
-          <br />
-          Bengaluru 560025
-        </p>
-        <a
-          className="text-xs text-bittersweet font-sans"
-          href="https://g.page/obvious-hq"
-        >
-          See on Google Maps
-        </a>
-      </div>
+    <div className="block">
+      <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
+        {title}
+      </span>
+      <p className="py-2 text-xs font-serif">{description}</p>
+      <a className="text-xs text-bittersweet font-sans" href={link}>
+        {linkText}
+      </a>
     </div>
   )
 }

--- a/src/components/ContactDetails.js
+++ b/src/components/ContactDetails.js
@@ -1,15 +1,14 @@
 import React from "react"
 
-export default ({ title, description, linkText, link }) => {
-  return (
-    <div className="block">
+export default ({ contactAsideBlock }) =>
+  contactAsideBlock.map(({ title, description, linktext, link }) => (
+    <div className="w-2/6 ml-auto">
       <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
         {title}
       </span>
       <p className="py-2 text-xs font-serif">{description}</p>
       <a className="text-xs text-bittersweet font-sans" href={link}>
-        {linkText}
+        {linktext}
       </a>
     </div>
-  )
-}
+  ))

--- a/src/components/ContactDetails.js
+++ b/src/components/ContactDetails.js
@@ -1,15 +1,15 @@
 import React from "react"
 
-export default ({ contactAsideBlock }) =>
+export default ({ details }) =>
   <div className="w-2/6 ml-auto">
-    {contactAsideBlock.map(({ title, description, linktext, link }) => (
+    {details.map(({ title, description, link }) => (
     <div>
       <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
         {title}
       </span>
       <p className="py-2 text-xs font-serif">{description}</p>
-      <a className="text-xs text-bittersweet font-sans" href={link}>
-        {linktext}
+      <a className="text-xs text-bittersweet font-sans" href={link.href}>
+        {link.text}
       </a>
     </div>
   ))}

--- a/src/components/ContactDetails.js
+++ b/src/components/ContactDetails.js
@@ -1,16 +1,27 @@
 import React from "react"
 
-export default ({ details }) =>
+export default ({ details }) => (
   <div className="w-2/6 ml-auto">
     {details.map(({ title, description, link }) => (
-    <div>
-      <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
-        {title}
-      </span>
-      <p className="py-2 text-xs font-serif">{description}</p>
-      <a className="text-xs text-bittersweet font-sans" href={link.href}>
-        {link.text}
-      </a>
-    </div>
-  ))}
+      <div>
+        <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
+          {title}
+        </span>
+        {link.typeoflink === "Email" ? (
+          <p className="py-2 text-xs font-serif">
+            <a href={`mailto:${description}`}>{description}</a>
+          </p>
+        ) : link.typeoflink === "Phone Number" ? (
+          <p className="py-2 text-xs font-serif">
+            <a href={`tel:${description}`}>{description}</a>
+          </p>
+        ) : (
+          <p className="py-2 text-xs font-serif">{description}</p>
+        )}
+        <a className="text-xs text-bittersweet font-sans" href={link.href}>
+          {link.text}
+        </a>
+      </div>
+    ))}
   </div>
+)

--- a/src/components/ContactDetails.js
+++ b/src/components/ContactDetails.js
@@ -1,8 +1,9 @@
 import React from "react"
 
 export default ({ contactAsideBlock }) =>
-  contactAsideBlock.map(({ title, description, linktext, link }) => (
-    <div className="w-2/6 ml-auto">
+  <div className="w-2/6 ml-auto">
+    {contactAsideBlock.map(({ title, description, linktext, link }) => (
+    <div>
       <span className="text-xs text-white block border-b border-gray-500 font-semibold py-2 font-sans">
         {title}
       </span>
@@ -11,4 +12,5 @@ export default ({ contactAsideBlock }) =>
         {linktext}
       </a>
     </div>
-  ))
+  ))}
+  </div>

--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -1,13 +1,13 @@
 import React from "react"
 
-export default ({ contactForm }) => {
+export default ({ title, description }) => {
   return (
     <div className="w-3/6">
       <h2 className="text-lg font-semibold text-white font-sans">
-        {contactForm.formtitle}
+        {title}
       </h2>
       <p className="text-sm py-2 font-serif">
-        {contactForm.formdescription}
+        {description}
       </p>
       <input
         className="bg-transparent border border-gray-400 rounded p-4 text-sm w-full my-1 font-sans"

--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -1,14 +1,13 @@
 import React from "react"
 
-export default ({ clients, category }) => {
+export default ({ contactForm }) => {
   return (
     <div className="w-3/6">
       <h2 className="text-lg font-semibold text-white font-sans">
-        Business Enquiries
+        {contactForm.formtitle}
       </h2>
       <p className="text-sm py-2 font-serif">
-        Interested in partnering with us? Tell us about your product and the
-        goals you want it to realise.
+        {contactForm.formdescription}
       </p>
       <input
         className="bg-transparent border border-gray-400 rounded p-4 text-sm w-full my-1 font-sans"

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,22 +1,56 @@
 import React from "react"
-// import { Link } from "gatsby"
+import { graphql } from "gatsby"
 
 import Layout from "../layouts/index"
 import HeroTitle from "../components/HeroTitle"
 import ContactForm from "../components/ContactForm"
 import ContactDetails from "../components/ContactDetails"
 
-export default () => (
-  <Layout>
-    <HeroTitle>Get in touch.</HeroTitle>
-    <div className="flex text-gray-400">
-      <ContactForm />
-    </div>
-  </Layout>
-)
+export default ({ data }) => {
+  const {
+    WP: { page },
+  } = data
+  return (
+    <Layout>
+      <HeroTitle>{page.contact.hero}</HeroTitle>
+      <div className="flex text-gray-400">
+        <ContactForm />
+        {page.contact.contactasideblock.map(
+          ({ title, description, hasLink, linktext, link }) => (
+            <div className="w-2/6 ml-auto flex flex-col">
               <ContactDetails
                 title={title}
                 description={description}
                 link={link}
                 linkText={linktext}
               />
+            </div>
+          )
+        )}
+        <ContactDetails />
+      </div>
+    </Layout>
+  )
+}
+
+export const query = graphql`
+  {
+    WP {
+      page(id: "cGFnZTozMQ==") {
+        contact {
+          hero
+          contactform {
+            formdescription
+          }
+          contactasideblock {
+            title
+            description
+            haslink
+            linktext
+            link
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -18,7 +18,7 @@ export default ({ data }) => {
           title={page.contact.form.title}
           description={page.contact.form.description}
         />
-        <ContactDetails contactAsideBlock={page.contact.details} />
+        <ContactDetails details={page.contact.details} />
       </div>
     </Layout>
   )

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -11,7 +11,12 @@ export default () => (
     <HeroTitle>Get in touch.</HeroTitle>
     <div className="flex text-gray-400">
       <ContactForm />
-      <ContactDetails />
     </div>
   </Layout>
 )
+              <ContactDetails
+                title={title}
+                description={description}
+                link={link}
+                linkText={linktext}
+              />

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -14,8 +14,11 @@ export default ({ data }) => {
     <Layout>
       <HeroTitle>{page.contact.hero}</HeroTitle>
       <div className="flex text-gray-400">
-        <ContactForm contactForm={page.contact.contactform} />
-        <ContactDetails contactAsideBlock={page.contact.contactasideblock} />
+        <ContactForm
+          title={page.contact.form.title}
+          description={page.contact.form.description}
+        />
+        <ContactDetails contactAsideBlock={page.contact.details} />
       </div>
     </Layout>
   )
@@ -27,15 +30,18 @@ export const query = graphql`
       page(id: "cGFnZTozMQ==") {
         contact {
           hero
-          contactform {
-            formtitle
-            formdescription
-          }
-          contactasideblock {
+          form {
             title
             description
-            linktext
-            link
+          }
+          details {
+            title
+            description
+            link {
+              text
+              href
+              isexternal
+            }
           }
         }
       }

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -40,7 +40,7 @@ export const query = graphql`
             link {
               text
               href
-              isexternal
+              typeoflink
             }
           }
         }

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -14,7 +14,7 @@ export default ({ data }) => {
     <Layout>
       <HeroTitle>{page.contact.hero}</HeroTitle>
       <div className="flex text-gray-400">
-        <ContactForm />
+        <ContactForm contactForm={page.contact.contactform} />
         <ContactDetails contactAsideBlock={page.contact.contactasideblock} />
       </div>
     </Layout>
@@ -28,6 +28,7 @@ export const query = graphql`
         contact {
           hero
           contactform {
+            formtitle
             formdescription
           }
           contactasideblock {

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -15,19 +15,7 @@ export default ({ data }) => {
       <HeroTitle>{page.contact.hero}</HeroTitle>
       <div className="flex text-gray-400">
         <ContactForm />
-        {page.contact.contactasideblock.map(
-          ({ title, description, hasLink, linktext, link }) => (
-            <div className="w-2/6 ml-auto flex flex-col">
-              <ContactDetails
-                title={title}
-                description={description}
-                link={link}
-                linkText={linktext}
-              />
-            </div>
-          )
-        )}
-        <ContactDetails />
+        <ContactDetails contactAsideBlock={page.contact.contactasideblock} />
       </div>
     </Layout>
   )
@@ -45,7 +33,6 @@ export const query = graphql`
           contactasideblock {
             title
             description
-            haslink
             linktext
             link
           }


### PR DESCRIPTION
This PR ensures that the Contact page on the website will use the (dashboard-based! editable!) data from our WP instance.