### PR TITLE
Tb/bring client page up to spec

### DIFF
--- a/src/components/ClientList.js
+++ b/src/components/ClientList.js
@@ -11,7 +11,7 @@ export default ({ listOfClientListBlocks }) => (
         <ul className="mt-4">
           {clientlistblock.namelist.map(({ name }) => (
             <li className="font-semibold text-xs py-1">
-              <Heading type="h5" className="text-gray-50 py-4">{name}</Heading>
+              <Heading type="h5" className="text-gray-50 pb-2">{name}</Heading>
                 </li>
           ))}
         </ul>

--- a/src/components/ClientList.js
+++ b/src/components/ClientList.js
@@ -1,15 +1,18 @@
 import React from "react"
+import { Heading } from "./Heading"
 
 export default ({ listOfClientListBlocks }) => (
   <div className="container py-2 text-gray-500 flex flex-wrap items-start justify-between font-sans">
     {listOfClientListBlocks.map(({ clientlistblock }) => (
       <div className="w-1/3 my-4 mr-4">
-        <h2 className="font-semibold text-xs text-white border-b border-gray-500 py-2">
+        <Heading type="h5" className="border-b border-gray-500 py-2">
           {clientlistblock.title}
-        </h2>
+        </Heading>
         <ul className="mt-4">
           {clientlistblock.namelist.map(({ name }) => (
-            <li className="font-semibold text-xs py-1">{name}</li>
+            <li className="font-semibold text-xs py-1">
+              <Heading type="h5" className="text-gray-50 py-4">{name}</Heading>
+                </li>
           ))}
         </ul>
       </div>

--- a/src/components/FeaturedClient.js
+++ b/src/components/FeaturedClient.js
@@ -8,7 +8,8 @@ export default ({ featuredClientBlock }) => (
     {featuredClientBlock.map(({ client, description, link }) => (
       <div className="w-1/3 my-4 mr-4 flex flex-col items-start">
         <Heading type="h3" className="font-medium">{client}</Heading>
-        <p className="py-2 font-serif">{description}</p>
+        <Heading type="body-large" className="py-2">{description}</Heading>
+        {/*TODO: Fix link*/}
         {link && (
           <a
             className="text-xs text-orange-50 font-sans flex justify-center items-center"

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -1,50 +1,51 @@
 import React from "react"
 
-export const Heading = ({ children, content, type }) => {
+export const Heading = ({ children, content, type, className }) => {
+  //TODO: Why are padding, etc able to be overridden but things like color are not responsive?
   switch (type) {
     case "h1":
       return (
-        <h1 className="font-sans font-bold text-gray-90 leading-none tracking-tight text-6xl">
+        <h1 className={`${className} font-sans font-bold text-gray-90 leading-none tracking-tight text-6xl`}>
           {children}
         </h1>
       )
     case "h2":
       return (
         //TODO: It is medium on FeaturedClient and semibold on ClientList. Can we standardise this/put this in the typography?
-        <h2 className="font-sans font-bold text-gray-90 leading-none tracking-tight text-5xl">
+        <h2 className={`${className} font-sans font-bold text-gray-90 leading-none tracking-tight text-5xl`}>
           {children}
         </h2>
       )
     case "h3":
       return (
-        <h3 className="font-sans font-bold text-gray-90 leading-none tracking-tight text-4xl">
+        <h3 className={`${className} font-sans font-bold text-gray-90 leading-none tracking-tight text-4xl`}>
           {children}
         </h3>
       )
     case "h4":
       return (
-        <h4 className="font-sans font-bold text-gray-90 leading-tight tracking-tight text-2xl">
+        <h4 className={`${className} font-sans font-bold text-gray-90 leading-tight tracking-tight text-2xl`}>
           {children}
         </h4>
       )
     case "h5":
       return (
-        <h5 className="font-sans font-bold text-gray-90 leading-tight tracking-tight text-lg">
+        <h5 className={`${className} font-sans font-bold text-gray-90 leading-tight tracking-tight text-lg`}>
           {children}
         </h5>
       )
     case "h6":
       return (
-        <h6 className="font-sans font-bold text-gray-90 leading-snug tracking-wider text-sm">
+        <h6 className={`${className} font-sans font-bold text-gray-90 leading-snug tracking-wider text-sm`}>
           {children}
         </h6>
       )
 
     case "body-large":
-      return <p className="font-serif font-medium text-xl leading-snug text-gray-50 tracking-tight">{children}</p>
+      return <p className={`${className} font-serif font-medium text-xl leading-snug text-gray-50 tracking-tight`}>{children}</p>
 
     case "body-medium":
-      return <p className="font-serif font-medium text-lg leading-snug text-gray-50 tracking-tight">{children}</p>
+      return <p className={`${className} font-serif font-medium text-lg leading-snug text-gray-50 tracking-tight`}>{children}</p>
 
     //TODO: Add styles to target html tags specifically so that they look like this and make sense.
     //TODO: Those tags should not override the styles mentioned above, and should be overridable by other styles.

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -39,8 +39,16 @@ export const Heading = ({ children, content, type }) => {
           {children}
         </h6>
       )
+
+    case "body-large":
+      return <p className="font-serif font-medium text-xl leading-snug text-gray-50 tracking-tight">{children}</p>
+
+    case "body-medium":
+      return <p className="font-serif font-medium text-lg leading-snug text-gray-50 tracking-tight">{children}</p>
+
     //TODO: Add styles to target html tags specifically so that they look like this and make sense.
     //TODO: Those tags should not override the styles mentioned above, and should be overridable by other styles.
+    //TODO: Also add hyperlink styles to this one
     /* This case is required to handle those blocks that come from WP Gutenberg.*/
     default:
       return <div dangerouslySetInnerHTML={{ __html: content }} />


### PR DESCRIPTION
This PR brings the components:
- Hero title padding 
- Featured Client 
- Client List 
up to spec. See also: https://linear.app/issue/NUWEB-94/bring-client-page-up-to-spec

Known issues with fixes in future iterations: 
- Rename `Heading` to Text in a safe way 
- Why are classes that have already been declared in the base component not overridden when passed to by the parent?