### PR TITLE
8 5/move to wp core fields

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,8 +1,8 @@
 import React from "react"
 import "../styles/Image.css"
 
-export default ({content, className}) => {
+export default ({className, src}) => {
   return (
-    <div className={className} dangerouslySetInnerHTML={{__html: content}} />
+    <img className={className} src={src} />
   )
 }

--- a/src/components/Quote.js
+++ b/src/components/Quote.js
@@ -2,16 +2,30 @@ import React from "react"
 import "../styles/quote.css"
 
 //TODO: Display separators above and below quote on mobile screens
+//Author has been dangerously set to account for the break in the citation value
+// that accommodates both name and designation.
 export default ({ children, author, bio }) => {
   return (
     <div className="quote-container my-4 lg:my-10">
-      <p className="font-serif font-extrabold text-xl text-grey-10 italic leading-relaxed" dangerouslySetInnerHTML={{__html: children}} />
-      { (author || bio) && <div>
-        {author && <span className="text-xs text-black font-sans font-semibold">
-          {author}
-        </span>}
-        {bio && <span className="text-xs text-black font-sans font-medium">{bio}</span>}
-      </div>}
+      <p
+        className="font-serif font-extrabold text-xl text-grey-10 italic leading-relaxed mb-8"
+        dangerouslySetInnerHTML={{ __html: children }}
+      />
+      {(author || bio) && (
+        <>
+          {author && (
+            <span
+              className="text-xs text-black font-sans font-semibold"
+              dangerouslySetInnerHTML={{ __html: author }}
+            />
+          )}
+          {bio && (
+            <span className="text-xs text-black font-sans font-medium">
+              {bio}
+            </span>
+          )}
+          </>
+      )}
     </div>
   )
 }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -28,7 +28,7 @@ function assignComponent(block, index) {
           key={index}
           type="body-medium"
           className="text-light/gray-10 my-2 lg:my-5"
-          content={block.paraattr.content}
+          content={block.paragraphattributes.content}
         />
       )
 
@@ -88,9 +88,9 @@ function assignComponent(block, index) {
       return (
         <Code
           key={index}
-          content={block.codeattr.content}
-          language={block.codeattr.language}
-          showLines={block.codeattr.lineNumbers}
+          content={block.codeattributes.content}
+          language={block.codeattributes.language}
+          showLines={block.codeattributes.lineNumbers}
         />
       )
 
@@ -181,7 +181,7 @@ export const query = graphql`
           parentId
           ... on WP_CoreParagraphBlock {
             name
-            paraattr: attributes {
+            paragraphattributes: attributes {
               ... on WP_CoreParagraphBlockAttributesV3 {
                 content
               }
@@ -189,7 +189,7 @@ export const query = graphql`
           }
           ... on WP_CoreCodeBlock {
             name
-            codeattr: attributes {
+            codeattributes: attributes {
               content
               language
               lineNumbers

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -227,6 +227,9 @@ export const query = graphql`
               citation
             }
           }
+          ... on WP_CoreSeparatorBlock {
+            name
+          }
         }
         content
         date

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -33,7 +33,15 @@ function assignComponent(block, index) {
       )
 
     case "core/heading":
-      return <Heading key={index} className="my-2 lg:my-5" content={content} />
+      return (
+        <Heading
+          key={index}
+          className="text-gray-10 my-2 lg:my-5"
+          type={`h${block.headingattributes.level}`}
+        >
+          {block.headingattributes.content}
+        </Heading>
+      )
 
     case "core/image":
       //TODO: w-full applies on lg, w-super otherwise
@@ -193,6 +201,13 @@ export const query = graphql`
               content
               language
               lineNumbers
+            }
+          }
+          ... on WP_CoreHeadingBlock {
+            name
+            headingattributes: attributes {
+              content
+              level
             }
           }
         }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -54,7 +54,11 @@ function assignComponent(block, index) {
       )
 
     case "core/quote":
-      return <Quote key={index}>{content}</Quote>
+      return (
+        <Quote key={index} author={block.quoteattributes.citation}>
+          {block.quoteattributes.value}
+        </Quote>
+      )
 
     case "core/columns":
       return (
@@ -214,6 +218,13 @@ export const query = graphql`
             name
             listattributes: attributes {
               values
+            }
+          }
+          ... on WP_CoreQuoteBlock {
+            name
+            quoteattributes: attributes {
+              value
+              citation
             }
           }
         }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -49,7 +49,7 @@ function assignComponent(block, index) {
         <Image
           key={index}
           className="w-full w-super my-9 lg:my-10 lg:mx-0 self-center"
-          content={content}
+          src={block.imageattributes.url}
         />
       )
 
@@ -196,6 +196,21 @@ export const query = graphql`
             paragraphattributes: attributes {
               ... on WP_CoreParagraphBlockAttributesV3 {
                 content
+              }
+            }
+          }
+          ... on WP_CoreImageBlock {
+            name
+            imageattributes: attributes {
+              alt
+              caption
+              url
+            }
+            imageFile {
+              childImageSharp {
+                fixed {
+                  ...GatsbyImageSharpFixed
+                }
               }
             }
           }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -14,20 +14,21 @@ import "../styles/article.css"
 import { Code } from "../components/Code"
 
 function assignComponent(block, index) {
-  const name = block.name
   const content = block.originalContent
   const innerBlocks = block.innerBlocks
   // List of all core block components available on the default gutenberg editor
   // TODO: all of these need to be implemented and taken care of in this switch (or disabled on the editor itself)
   // https://gist.github.com/DavidPeralvarez/37c8c148f890d946fadb2c25589baf00#file-core-blocks-txt
-  switch (name) {
+  switch (block.name) {
     case "core/paragraph":
+      //We still use dangerouslySetInnerHTML here because the content field still
+      //gives us html within the response - ex em, strong, a, and code tags
       return (
         <BodyText
           key={index}
           type="body-medium"
           className="text-light/gray-10 my-2 lg:my-5"
-          content={content}
+          content={block.paraattr.content}
         />
       )
 
@@ -86,14 +87,15 @@ function assignComponent(block, index) {
     case "core/code":
       return (
         <Code
-          content={block.attributes.content}
-          language={block.attributes.language}
-          showLines={block.attributes.lineNumbers}
+          key={index}
+          content={block.codeattr.content}
+          language={block.codeattr.language}
+          showLines={block.codeattr.lineNumbers}
         />
       )
 
     default:
-      console.error(name, content)
+      console.error(block.name, content)
   }
 }
 
@@ -176,9 +178,18 @@ export const query = graphql`
               }
             }
           }
+          parentId
+          ... on WP_CoreParagraphBlock {
+            name
+            paraattr: attributes {
+              ... on WP_CoreParagraphBlockAttributesV3 {
+                content
+              }
+            }
+          }
           ... on WP_CoreCodeBlock {
             name
-            attributes {
+            codeattr: attributes {
               content
               language
               lineNumbers

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -37,10 +37,8 @@ function assignComponent(block, index) {
         <Heading
           key={index}
           className="text-gray-10 my-2 lg:my-5"
-          type={`h${block.headingattributes.level}`}
-        >
-          {block.headingattributes.content}
-        </Heading>
+          content={content}
+        />
       )
 
     case "core/image":
@@ -224,10 +222,7 @@ export const query = graphql`
           }
           ... on WP_CoreHeadingBlock {
             name
-            headingattributes: attributes {
-              content
-              level
-            }
+            originalContent
           }
           ... on WP_CoreListBlock {
             name

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -49,7 +49,7 @@ function assignComponent(block, index) {
         <Image
           key={index}
           className="w-full w-super my-9 lg:my-10 lg:mx-0 self-center"
-          src={block.imageattributes.url}
+          src={block.attributes.url}
         />
       )
 
@@ -201,7 +201,7 @@ export const query = graphql`
           }
           ... on WP_CoreImageBlock {
             name
-            imageattributes: attributes {
+            attributes {
               alt
               caption
               url

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -88,7 +88,7 @@ function assignComponent(block, index) {
           key={index}
           type="body-medium"
           className="text-light/gray-10 my-8 lg:mb-20 ml-8 lg:ml-16"
-          content={content}
+          content={block.listattributes.values}
         />
       )
 
@@ -208,6 +208,12 @@ export const query = graphql`
             headingattributes: attributes {
               content
               level
+            }
+          }
+          ... on WP_CoreListBlock {
+            name
+            listattributes: attributes {
+              values
             }
           }
         }


### PR DESCRIPTION
This PR closes https://linear.app/issue/NUWEB-133/[gutenberg]-use-wp_core-graphql-fields-in-articleblocks-to-render